### PR TITLE
E2e/deploy to versioned path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -317,7 +317,7 @@ workflows:
           stage: beta
           name: deploy-beta
           requires:
-            - deploy-e2e-page-beta
+            - test-e2e-electron-beta
           filters:
             branches:
               only:
@@ -327,7 +327,7 @@ workflows:
           stage: stable
           name: deploy-stable
           requires:
-            - deploy-e2e-page-stable
+            - test-e2e-electron-stable
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,20 @@
 version: 2.1
 
 jobs:
-  install:
+  preconditions:
     docker: &BUILDIMAGE
       - image: jenkinsrise/cci-v2-components:0.0.5
+    steps:
+      - checkout
+      - run: |
+          if [ -z $(grep version package.json |grep -o '[0-9.]*') ]
+          then
+            echo Version must be specified in package.json
+            exit 1
+          fi
+
+  install:
+    docker: *BUILDIMAGE
     steps:
       - checkout
       - restore_cache:
@@ -184,27 +195,37 @@ jobs:
       - run: cp -r gcloud ~/.config
       - run: npm install common-component
       - run: |
-          TARGET=$WIDGETS_BASE/<< parameters.stage >>/components/rise-text/
-          echo Deploying << parameters.stage >> version of rise-text
+          MAJOR=$(grep version package.json | grep -Po '[0-9]+' | head -1)
+          TARGET=$WIDGETS_BASE/<< parameters.stage >>/components/rise-text/$MAJOR/
+          echo Deploying << parameters.stage >> version of rise-text/$MAJOR
           node_modules/common-component/deploy-gcs.sh rise-text $TARGET
 
 workflows:
   workflow1:
     jobs:
-      - install
+      - preconditions
+      - install:
+          requires:
+            - preconditions
       - gcloud-setup:
+          requires:
+            - preconditions
           filters:
             branches:
               only:
                 - /^(stage|staging)[/].*/
                 - master
+                - /^e2e[/].*/
                 - build/stable
       - generate-version:
+          requires:
+            - preconditions
           filters:
             branches:
               only:
                 - /^(stage|staging)[/].*/
                 - master
+                - /^e2e[/].*/
                 - build/stable
       - test:
           requires:
@@ -218,6 +239,7 @@ workflows:
               only:
                 - /^(stage|staging)[/].*/
                 - master
+                - /^e2e[/].*/
                 - build/stable
       - build-e2e-page:
           stage: beta
@@ -228,6 +250,7 @@ workflows:
             branches:
               only:
                 - master
+                - /^e2e[/].*/
       - build-e2e-page:
           stage: stable
           name: build-e2e-page-stable
@@ -246,6 +269,7 @@ workflows:
               only:
                 - /^(stage|staging)[/].*/
                 - master
+                - /^e2e[/].*/
                 - build/stable
       - deploy-e2e-page:
           stage: beta
@@ -257,6 +281,7 @@ workflows:
             branches:
               only:
                 - master
+                - /^e2e[/].*/
       - deploy-e2e-page:
           stage: stable
           name: deploy-e2e-page-stable
@@ -278,6 +303,7 @@ workflows:
             branches:
               only:
                 - master
+                - /^e2e[/].*/
       - test-e2e-electron:
           displayId: 32ZRW9NCJP5T
           installerPath: /

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -322,7 +322,6 @@ workflows:
             branches:
               only:
                 - master
-                - /^e2e[/].*/
       - deploy-production:
           stage: stable
           name: deploy-stable

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,8 +90,6 @@ jobs:
           sed "
             s/__STAGE__/<< parameters.stage >>/;
             s/__VERSION__/$VERSION/;
-            s/__PLAYER__/electron/;
-            s/__CONNECTION__/websocket/;
           " e2e/rise-text.html > e2e/rise-text-electron.html
       - run: cp e2e/polymer-e2e-electron.json polymer.json
       - run: polymer build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -323,6 +323,7 @@ workflows:
             branches:
               only:
                 - master
+                - /^e2e[/].*/
       - deploy-production:
           stage: stable
           name: deploy-stable

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -317,8 +317,7 @@ workflows:
           stage: beta
           name: deploy-beta
           requires:
-            - gcloud-setup
-            - build
+            - deploy-e2e-page-beta
           filters:
             branches:
               only:
@@ -328,8 +327,7 @@ workflows:
           stage: stable
           name: deploy-stable
           requires:
-            - gcloud-setup
-            - build
+            - deploy-e2e-page-stable
           filters:
             branches:
               only:

--- a/demo/src/rise-text.html
+++ b/demo/src/rise-text.html
@@ -18,7 +18,7 @@
   </script>
   <script src="https://widgets.risevision.com/beta/common/config-test.min.js"></script>
   <script src="https://widgets.risevision.com/beta/common/common-template.min.js"></script>
-  <script src="https://widgets.risevision.com/beta/components/rise-text/rise-text.js"></script>
+  <script src="https://widgets.risevision.com/beta/components/rise-text/1/rise-text.js"></script>
   <script>
     if (document.domain.indexOf("localhost") === -1) {
       try {

--- a/e2e/rise-text.html
+++ b/e2e/rise-text.html
@@ -53,18 +53,7 @@
       } );
     </script>
     <script>
-      // electron / websocket or chromeos / window
-      RisePlayerConfiguration.configure({
-        displayId: "Y8SAH3CQ6NMP",
-        companyId: "7fa5ee92-7deb-450b-a8d5-e5ed648c575f",
-        playerType: "__STAGE__",
-        playerVersion: "TEST_VERSION",
-        os: "TEST_OS"
-      }, {
-        player: "__PLAYER__",
-        connectionType: "__CONNECTION__",
-        detail: { serverUrl: "http://localhost:8080" }
-      });
+      RisePlayerConfiguration.configure();
     </script>
   </body>
 </html>


### PR DESCRIPTION
Changes to deploy to versioned path as mentioned here: https://github.com/Rise-Vision/rise-image/pull/8

I tested deployment, and the beta script is being generated as expected here:
https://console.cloud.google.com/storage/browser/widgets.risevision.com/beta/components/rise-text/1/?project=avid-life-623&pli=1

I also did some simplifications to the e2e page configuration and page build, as some parameters are needed for rise-data-financial / financial selector, but not needed for a simple component as rise-text.

I also modified dependencies of production deployment, as it shouldn't run before e2e finish successfully.
