### PR TITLE
Fix for #18 - missing version number

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,11 @@ jobs:
           at: .
       - restore_cache:
           key: node-cache-{{ checksum "package.json" }}
+      - run: |
+          VERSION=$(cat version-string/version)
+          sed -i "
+            s/__VERSION__/$VERSION/;
+          " src/rise-text-version.js
       - run: npm run build
       - persist_to_workspace:
           root: .

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-text",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/rise-text-version.js
+++ b/src/rise-text-version.js
@@ -1,0 +1,1 @@
+export const version = "__VERSION__";

--- a/src/rise-text.js
+++ b/src/rise-text.js
@@ -1,5 +1,6 @@
 import { html } from "@polymer/polymer";
 import { RiseElement } from "rise-common-component/src/rise-element.js";
+import { version } from "./rise-text-version.js";
 
 export default class RiseText extends RiseElement {
 
@@ -23,6 +24,8 @@ export default class RiseText extends RiseElement {
 
   constructor() {
     super();
+
+    this._setVersion( version );
   }
 
   _valueChanged(newValue, oldValue) {


### PR DESCRIPTION
## Description
Fix for #18  - "rise-text is not reporting its component version to BQ"

## Motivation and Context
rise-text was not setting the version number during the build

## How Has This Been Tested?
Used Charles proxy to load staged version of rise-text and verified that correct version was reported to BQ using query
```
#StandardSQL
SELECT version
FROM `client-side-events.Display_Events.events` 
WHERE ts >= TIMESTAMP(DATE_ADD(CURRENT_DATE(), INTERVAL -1 DAY)) -- previous and current days
AND source = 'rise-text'
group by version
```

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
