### PR TITLE
Add support for fontsize property

### DIFF
--- a/demo/src/rise-text-dev.html
+++ b/demo/src/rise-text-dev.html
@@ -33,7 +33,7 @@
 
 <body>
 
-  <rise-text value="Hello World!">
+  <rise-text value="Hello World!" fontsize="100">
   </rise-text>
 
   <script>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-text",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Web component for displaying text on a Rise Vision Template page",
   "scripts": {
     "prebuild": "eslint .",

--- a/src/rise-text.js
+++ b/src/rise-text.js
@@ -1,11 +1,15 @@
 import { html } from "@polymer/polymer";
+import "@polymer/polymer/lib/elements/dom-if.js";
 import { RiseElement } from "rise-common-component/src/rise-element.js";
 import { version } from "./rise-text-version.js";
 
 export default class RiseText extends RiseElement {
 
   static get template() {
-    return html`[[value]]`;
+    return html`
+      <template is="dom-if" if="{{fontsize > 0}}"><span style="font-size: [[fontsize]]px">[[value]]</span></template>
+      <template is="dom-if" if="{{!fontsize}}">[[value]]</template>
+    `;
   }
 
   static get properties() {
@@ -13,8 +17,11 @@ export default class RiseText extends RiseElement {
       value: {
         type: String,
         observer: "_valueChanged"
+      },
+      fontsize: {
+        type: Number
       }
-    }
+    };
   }
 
   // Event name constants

--- a/src/rise-text.js
+++ b/src/rise-text.js
@@ -7,8 +7,8 @@ export default class RiseText extends RiseElement {
 
   static get template() {
     return html`
-      <template is="dom-if" if="{{fontsize > 0}}"><span style="font-size: [[fontsize]]px">[[value]]</span></template>
-      <template is="dom-if" if="{{!fontsize}}">[[value]]</template>
+      <template is="dom-if" if="{{validFont}}"><span style="font-size: [[fontsize]]px">[[value]]</span></template>
+      <template is="dom-if" if="{{!validFont}}">[[value]]</template>
     `;
   }
 
@@ -19,7 +19,12 @@ export default class RiseText extends RiseElement {
         observer: "_valueChanged"
       },
       fontsize: {
-        type: Number
+        type: Number,
+        observer: "_fontsizeChanged"
+      },
+      validFont: {
+        type: Boolean,
+        value: false
       }
     };
   }
@@ -37,6 +42,10 @@ export default class RiseText extends RiseElement {
 
   _valueChanged(newValue, oldValue) {
     super._sendEvent( RiseText.EVENT_DATA_UPDATE, {newValue, oldValue});
+  }
+
+  _fontsizeChanged(newValue) {
+    this.validFont = newValue && newValue > 0;
   }
 }
 

--- a/src/rise-text.js
+++ b/src/rise-text.js
@@ -34,14 +34,17 @@ export default class RiseText extends RiseElement {
     super();
 
     this._setVersion( version );
+    this.validFont = false;
   }
 
   _valueChanged(newValue, oldValue) {
-    super._sendEvent( RiseText.EVENT_DATA_UPDATE, {newValue, oldValue});
+    super._sendEvent( RiseText.EVENT_DATA_UPDATE, {newValue, oldValue, fontsize: this.fontsize});
   }
 
   _fontsizeChanged(newValue) {
     this.validFont = newValue && newValue > 0;
+
+    super._sendEvent( RiseText.EVENT_DATA_UPDATE, {newValue: this.value, oldValue: this.value, fontsize: this.fontsize});
   }
 }
 

--- a/src/rise-text.js
+++ b/src/rise-text.js
@@ -21,10 +21,6 @@ export default class RiseText extends RiseElement {
       fontsize: {
         type: Number,
         observer: "_fontsizeChanged"
-      },
-      validFont: {
-        type: Boolean,
-        value: false
       }
     };
   }

--- a/test/rise-text-test.html
+++ b/test/rise-text-test.html
@@ -80,6 +80,31 @@
           element.ready();
         });
 
+        suite('validFont', () => {
+          test('validFont should be set to true when fontsize is valid', (done) => {
+            const element = fixture('StaticValueTestFixture');
+
+            element.ready();
+            element.fontsize = 100;
+
+            setTimeout(() => {
+              assert(element.validFont);
+              done();
+            }, 100);
+          });
+
+          test('validFont should be set to false when fontsize is not valid', (done) => {
+            const element = fixture('StaticValueTestFixture');
+
+            element.ready();
+            element.fontsize = -1;
+
+            setTimeout(() => {
+              assert(!element.validFont);
+              done();
+            }, 100);
+          });
+        });
       });
     </script>
 


### PR DESCRIPTION
## Description
Adds support for `fontsize` property, using conditional templating to show the additional `style` attribute.

## Motivation and Context
It was part of a Hackathon project.

## How Has This Been Tested?
Tested locally with the `-dev` version of the Demo page.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No.

@stulees please review