### PR TITLE
Fix dom-if import issue

### DIFF
--- a/demo/src/rise-text.html
+++ b/demo/src/rise-text.html
@@ -12,9 +12,11 @@
   <script type="module">
     // this and the following block are needed at build time to force the creation of the shared bundle script
     import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+    import "@polymer/polymer/lib/elements/dom-if.js";
   </script>
   <script type="module">
     import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+    import "@polymer/polymer/lib/elements/dom-if.js";
   </script>
   <script src="https://widgets.risevision.com/beta/common/config-test.min.js"></script>
   <script src="https://widgets.risevision.com/beta/common/common-template.min.js"></script>

--- a/e2e/rise-text.html
+++ b/e2e/rise-text.html
@@ -25,9 +25,11 @@
     <script type="module">
       // this and the following block are needed at build time to force the creation of the shared bundle script
       import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+      import "@polymer/polymer/lib/elements/dom-if.js";
     </script>
     <script type="module">
       import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+      import "@polymer/polymer/lib/elements/dom-if.js";
     </script>
     <script src="https://widgets.risevision.com/__STAGE__/common/config-test.min.js"></script>
     <script src="https://widgets.risevision.com/__STAGE__/common/common-template.min.js"></script>

--- a/html/index.html
+++ b/html/index.html
@@ -9,6 +9,7 @@
   <script type="module">
     // Basic noop script that helps forcing shared bundle file creation.
     import { PolymerElement } from '@polymer/polymer/polymer-element.js';
+    import "@polymer/polymer/lib/elements/dom-if.js";
   </script>
   <script src="../src/rise-text.js" type="module"></script>
 </head>


### PR DESCRIPTION
## Description
Fixes the import issue described in this document: https://docs.google.com/document/d/1rnKfE1DhDQHWu8O1zfmoYn5uF5yqaq-wXe2A48tplJU/edit#heading=h.utvde6s4phvf

## Motivation and Context
Without this fix, `rise-text` instances can't coexist with `rise-image`.

## How Has This Been Tested?
It can be tested here: https://apps-stage-7.risevision.com/templates/edit/9094f0e7-8c65-4ea6-9b4b-ede183a08c34/?cid=87977ab8-38b6-47fb-ad5e-256b8cc4b46d

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No

@santiagonoguez @stulees please review