### PR TITLE
Leveraging rise-element for common constants

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-text",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -365,9 +365,9 @@
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.0.tgz",
-      "integrity": "sha512-Uvq6hVe90D0B2WEnUqtdgY1bATGz3mw33nH9Y+dmA+w5DHvUmBgkr5rM/KCHpCsiFNRUfokW/szpPPgMK2hm4A=="
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
+      "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -1732,16 +1732,16 @@
       }
     },
     "mime-db": {
-      "version": "1.42.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.42.0.tgz",
-      "integrity": "sha512-UbfJCR4UAVRNgMpfImz05smAXK7+c+ZntjaA26ANtkXLlOe947Aag5zdIcKQULAiF9Cq4WxBi9jUs5zkA84bYQ=="
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
+      "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
     },
     "mime-types": {
-      "version": "2.1.25",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.25.tgz",
-      "integrity": "sha512-5KhStqB5xpTAeGqKBAMgwaYMnQik7teQN4IAzC7npDv6kzeU6prfkR67bc87J1kWMPGkoaZSq1npmexMgkmEVg==",
+      "version": "2.1.26",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
+      "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
       "requires": {
-        "mime-db": "1.42.0"
+        "mime-db": "1.43.0"
       }
     },
     "mimic-fn": {
@@ -2309,8 +2309,8 @@
       }
     },
     "rise-common-component": {
-      "version": "git://github.com/Rise-Vision/rise-common-component.git#ff74c44d9e27619e87d30c053842405b72f48f8a",
-      "from": "git://github.com/Rise-Vision/rise-common-component.git#v1.3.0",
+      "version": "git://github.com/Rise-Vision/rise-common-component.git#4967ae81a92f9d97abfe4c9c2d02c018951a32b5",
+      "from": "git://github.com/Rise-Vision/rise-common-component.git#v1.3.1",
       "requires": {
         "@polymer/polymer": "3.1.0",
         "@polymer/test-fixture": "~4.0.2",
@@ -2675,9 +2675,9 @@
       }
     },
     "uuid": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@polymer/polymer": "3.1.0",
     "@webcomponents/webcomponentsjs": "^2.1.3",
-    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#v1.3.0"
+    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#v1.3.1"
   },
   "devDependencies": {
     "@polymer/test-fixture": "^4.0.2",

--- a/src/rise-text.js
+++ b/src/rise-text.js
@@ -25,11 +25,6 @@ export default class RiseText extends RiseElement {
     };
   }
 
-  // Event name constants
-  static get EVENT_DATA_UPDATE() {
-    return "data-update";
-  }
-
   constructor() {
     super();
 


### PR DESCRIPTION
## Description
Use latest rise-common-component repo to leverage rise-element for common constants

## Motivation and Context
Improve component code base

## How Has This Been Tested?
Using Charles to map to local version of component for this presentation - https://apps.risevision.com/templates/edit/b8c1735f-79d8-4794-8921-ad5d5e20b115/?cid=7fa5ee92-7deb-450b-a8d5-e5ed648c575f

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
  - Low risk, rollback requires re-running last master deployment in CCI and then revert code changes. 
  - Release on Monday
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
- Support, documentation: low risk change
