### PR TITLE
Add multiline attribute to support line breaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ If it's not set, the label for the component defaults to "Text", which is applie
 
 The component provides an additional numeric property, `fontsize`, which can be used to specify a size in pixel units. This property exists mainly to allow users customization of `rise-text` instances on Attribute Editor. If not provided in the template, the size of the text component will depend on external styling (it can still be customized on Attribute Editor).
 
+Also, by setting `multiline` attribute to `true`, the component is capable of handling line breaks from `value` and present them in multiple lines.
+
 ### Attributes
 
 This component receives the following list of attributes:
@@ -38,6 +40,7 @@ This component receives the following list of attributes:
 - **fontsize**: ( numeric / optional ): The size in pixels of the component to be rendered. If not provided, it relies on external styling.
 - **minfontsize**: (numeric / optional ): The minimum value the fontsize attribute can accept. Defaults to 1.
 - **maxfontsize**: (numeric / optional ): The maximum value the fontsize attribute can accept. Defaults to 200.
+- **multiline**: (boolean / optional ): If set to `true`, the component will preserve `value` line breaks and show them in multiple lines. Defaults to `false`.
 - **label**: ( string / optional ): An optional label key for the text that will appear in the template editor. See 'Labels' section above.
 - **non-editable**: ( empty / optional ): If present, it indicates this component is not available for customization in the template editor.
 

--- a/demo/src/rise-text-dev.html
+++ b/demo/src/rise-text-dev.html
@@ -33,7 +33,8 @@
 
 <body>
 
-  <rise-text value="Hello World!" fontsize="100">
+  <rise-text value="Hello
+   World!" fontsize="100" multiline="true">
   </rise-text>
 
   <script>

--- a/e2e/rise-text.html
+++ b/e2e/rise-text.html
@@ -16,6 +16,10 @@
       .green {
         color: green;
       }
+      .yellow {
+        color: yellow;
+        background-color: black;
+      }
     </style>
 
     <script src="https://widgets.risevision.com/scripts/primus-local-messaging.js"></script>
@@ -54,6 +58,9 @@
     <rise-text value="Hello World!" class="text red"></rise-text>
     <br />
     <rise-text value="Hello World!" class="text green"></rise-text>
+    <br />
+    <rise-text value="Line 
+      Break!" class="text yellow"></rise-text>
 
     <script>
       function configureComponents() {

--- a/e2e/rise-text.html
+++ b/e2e/rise-text.html
@@ -57,10 +57,11 @@
     <br />
     <rise-text value="Hello World!" class="text red"></rise-text>
     <br />
-    <rise-text value="Hello World!" class="text green"></rise-text>
+    <rise-text value="Hello
+     World!" class="text green" multiline="false"></rise-text>
     <br />
     <rise-text value="Line 
-      Break!" class="text yellow"></rise-text>
+      Break!" class="text yellow" multiline="true"></rise-text>
 
     <script>
       function configureComponents() {

--- a/src/rise-text.js
+++ b/src/rise-text.js
@@ -41,7 +41,8 @@ export default class RiseText extends RiseElement {
         observer: "_checkFontSize"
       },
       multiline: {
-        type: Boolean
+        type: Boolean,
+        value: false
       }
     };
   }

--- a/src/rise-text.js
+++ b/src/rise-text.js
@@ -10,8 +10,8 @@ export default class RiseText extends RiseElement {
 
   static get template() {
     return html`
-      <template is="dom-if" if="{{validFont}}"><span style="font-size: [[fontsize]]px">[[value]]</span></template>
-      <template is="dom-if" if="{{!validFont}}">[[value]]</template>
+      <template is="dom-if" if="{{validFont}}"><span style="font-size: [[fontsize]]px; white-space: pre-wrap;">[[value]]</span></template>
+      <template is="dom-if" if="{{!validFont}}"><span style="white-space: pre-wrap;">[[value]]</span></template>
     `;
   }
 

--- a/src/rise-text.js
+++ b/src/rise-text.js
@@ -10,8 +10,13 @@ export default class RiseText extends RiseElement {
 
   static get template() {
     return html`
-      <template is="dom-if" if="{{validFont}}"><span style="font-size: [[fontsize]]px; white-space: pre-wrap;">[[value]]</span></template>
-      <template is="dom-if" if="{{!validFont}}"><span style="white-space: pre-wrap;">[[value]]</span></template>
+      <style>
+        :host([multiline=true]) span {
+          white-space: pre-wrap;
+        }
+      </style>
+      <template is="dom-if" if="{{validFont}}"><span style="font-size: [[fontsize]]px;">[[value]]</span></template>
+      <template is="dom-if" if="{{!validFont}}"><span>[[value]]</span></template>
     `;
   }
 
@@ -34,6 +39,9 @@ export default class RiseText extends RiseElement {
         type: Number,
         value: MAX_TEXT_SIZE,
         observer: "_checkFontSize"
+      },
+      multiline: {
+        type: Boolean
       }
     };
   }

--- a/test/rise-text-test.html
+++ b/test/rise-text-test.html
@@ -25,7 +25,7 @@
 
     <test-fixture id="StaticValueTestFixture">
       <template>
-        <rise-text value="Hello World"></rise-text>
+        <rise-text value="Hello World" multiline="true"></rise-text>
       </template>
     </test-fixture>
 
@@ -89,6 +89,10 @@
           });
 
           element['value'] = 'New Value 2';
+        });
+
+        test('setting "multiline" attribute on the element works', () => {
+          assert.equal(element.multiline, true);
         });
 
         test('"configured" event should be sent when "ready" is called', (done) => {


### PR DESCRIPTION
## Description
Added `multiline` attribute to support line breaks.
It uses `white-space: pre-wrap;`to preserve line breaks and spaces entered by the users in the UI.
Also updated e2e tests and screenshot to include a multiline example.

## Motivation and Context
Apps UX Improvement epic.

## How Has This Been Tested?
Locally and on stage-1 .
To validate, use Charles Proxy to map https://widgets.risevision.com/beta/components/rise-text/3/rise-text.js to https://widgets.risevision.com/staging/components/rise-text/2020.03.11.17.22/rise-text.js and check 'Main Message - Multiline' component on [stage-1 with sample template](https://apps-stage-1.risevision.com/templates/edit/25c99d9e-dc5b-47c1-992b-d37b622d5401/?cid=b428b4e8-c8b9-41d5-8a10-b4193c789443).

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
