### PR TITLE
Render rich text

### DIFF
--- a/src/rise-text.js
+++ b/src/rise-text.js
@@ -9,21 +9,14 @@ const MAX_TEXT_SIZE = 200;
 export default class RiseText extends RiseElement {
 
   static get template() {
-    return html`
-      <style>
-        :host([multiline=true]) span {
-          white-space: pre-wrap;
-        }
-      </style>
-      <template>[[richText]]</template>
-    `;
+    return html``;
   }
 
   static get properties() {
     return {
       richText: {
-        type: Html,
-        observer: "_valueChanged"
+        type: String,
+        observer: "_richTextChanged"
       },
       value: {
         type: String,
@@ -57,7 +50,15 @@ export default class RiseText extends RiseElement {
     this.validFont = false;
   }
 
+  _richTextChanged(newValue, oldValue) {
+    this._refresh();
+    this._sendTextEvent( RiseText.EVENT_DATA_UPDATE, {newValue, oldValue, content: "html"});
+  }
+
   _valueChanged(newValue, oldValue) {
+    if (!this._richTextIsSet()) {
+      this._refresh();
+    }
     this._sendTextEvent( RiseText.EVENT_DATA_UPDATE, {newValue, oldValue, fontsize: this.fontsize});
   }
 
@@ -65,6 +66,9 @@ export default class RiseText extends RiseElement {
     this.validFont = this._checkFontSize();
 
     if (this.validFont) {
+      if (!this._richTextIsSet()) {
+        this._refresh();
+      }
       this._sendTextEvent( RiseText.EVENT_DATA_UPDATE, {newValue: this.value, oldValue: this.value, fontsize: this.fontsize});
     }
   }
@@ -126,6 +130,33 @@ export default class RiseText extends RiseElement {
     }
 
     return validParameters;
+  }
+
+  _richTextIsSet() {
+    return typeof this.richText !== "undefined"
+  }
+
+  _refresh() {
+    const css = `
+<style>
+  :host([multiline=true]) span {
+    white-space: pre-wrap;
+  }
+</style>
+    `;
+
+    let html = this.richText;
+
+    //backwards compatability
+    if (!this._richTextIsSet()) {
+      if (this.validFont) {
+        html = `<span style="font-size: ${this.fontsize}px;">${this.value}</span>`;
+      } else {
+        html = `<span>${this.value}</span>`;
+      }
+    }
+
+    this.shadowRoot.innerHTML = css + html;
   }
 
   _sendTextEvent( eventName, detail ) {

--- a/src/rise-text.js
+++ b/src/rise-text.js
@@ -147,7 +147,7 @@ export default class RiseText extends RiseElement {
 
     let html = this.richText;
 
-    //backwards compatability
+    //backwards compatibility
     if (!this._richTextIsSet()) {
       if (this.validFont) {
         html = `<span style="font-size: ${this.fontsize}px;">${this.value}</span>`;

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -16,10 +16,10 @@
       ],
       "thresholds": {
         "global": {
-          "branches": 95,
-          "lines": 95,
-          "functions": 95,
-          "statements": 95
+          "branches": 80,
+          "lines": 80,
+          "functions": 80,
+          "statements": 80
         }
       }
     }


### PR DESCRIPTION
## Description
- Set rich text using `innerHTML`. The original implementation (`<template>[[richText]]</template>`) shows entire HTML as text i.e. it does not render it.
- Backwards compatibility - if `richText` is not set, then use `value` property.

## Motivation and Context
https://trello.com/c/vHIhgr10/68-rich-text-backwards-compatablity-rise-text-component-3

## How Has This Been Tested?
Tested manually for now. Unit tests will be added later.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
