### PR TITLE
Add new dist file that points to polymer-bundle.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
   },
   "homepage": "https://github.com/Rise-Vision/rise-text/#readme",
   "dependencies": {
-    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#54c42fa"
+    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#v1.9.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-text",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "Web component for displaying text on a Rise Vision Template page",
   "scripts": {
     "prebuild": "eslint .",
@@ -26,6 +26,6 @@
   },
   "homepage": "https://github.com/Rise-Vision/rise-text/#readme",
   "dependencies": {
-    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#v1.9.1"
+    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#54c42fa"
   }
 }


### PR DESCRIPTION
## Description
Adds an extra distribution file (dist/rise-text-bundle.min.js) that references a static version of polymer and dependencies instead of relative to the template.

## Motivation and Context
Please check notes from: https://github.com/Rise-Vision/rise-common-component/pull/73

## How Has This Been Tested?
Same as https://github.com/Rise-Vision/rise-common-component/pull/73:
https://storage.googleapis.com/risemedialibrary-554d3ef9-78b7-4726-8f46-c1ec140c166d/html-template-test/index.html

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
